### PR TITLE
add general information about djinni to plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/PLUGIN_ID.svg)](https://plugins.jetbrains.com/plugin/PLUGIN_ID)
 
 <!-- Plugin description -->
-Add some basic navigation, code-completion and error highlighting support to .djinni files.
+Adds basic navigation, code-completion and error highlighting support for `.djinni` IDL files.
+
+Djinni is a tool for generating cross-language type declarations and interface bindings. It's designed to connect C++ with either Java or Objective-C.
 <!-- Plugin description end -->
 
 ## Installation


### PR DESCRIPTION
fixes #9 

During review process a more detailed plugin-description was requested.
Therefore I added a general description of what djinni is. Additionally (not in this PR) I added a screenshot to the marketplace, that shows a simple example of how the code-completion provided by the plugin looks like:

<img width="715" alt="djinni_intellij_example" src="https://user-images.githubusercontent.com/21294002/98470257-c10c4900-21e4-11eb-993d-33308c2c743a.png">
