### PR TITLE
fixed: interfaces can now have `const` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 ### Fixed
+- interfaces can now have `const` methods.
+
+## [0.10.1]
+### Fixed
 - problem with new `flags` support: `all` and `none` must not interpreted as language keywords.
 
 ## [0.10.0]

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.cross_language_cpp.djinni_intellij_plugin
 pluginName_ = djinni-intellij-plugin
-pluginVersion = 0.10.1
+pluginVersion = 0.10.2
 pluginSinceBuild = 193
 pluginUntilBuild = 202.*
 

--- a/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/parser/DjinniParser.java
+++ b/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/parser/DjinniParser.java
@@ -596,10 +596,9 @@ public class DjinniParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // [static] identifier LEFT_PARAM_BRACE interfaceFunctionParamList? RIGHT_PARAM_BRACE [COLON typeReference] SEMICOLON
+  // [static | const] identifier LEFT_PARAM_BRACE interfaceFunctionParamList? RIGHT_PARAM_BRACE [COLON typeReference] SEMICOLON
   public static boolean interfaceMemberFunction(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interfaceMemberFunction")) return false;
-    if (!nextTokenIs(b, "<interface member function>", IDENTIFIER, STATIC)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, INTERFACE_MEMBER_FUNCTION, "<interface member function>");
     r = interfaceMemberFunction_0(b, l + 1);
@@ -612,11 +611,20 @@ public class DjinniParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // [static]
+  // [static | const]
   private static boolean interfaceMemberFunction_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interfaceMemberFunction_0")) return false;
-    consumeToken(b, STATIC);
+    interfaceMemberFunction_0_0(b, l + 1);
     return true;
+  }
+
+  // static | const
+  private static boolean interfaceMemberFunction_0_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "interfaceMemberFunction_0_0")) return false;
+    boolean r;
+    r = consumeToken(b, STATIC);
+    if (!r) r = consumeToken(b, CONST);
+    return r;
   }
 
   // interfaceFunctionParamList?

--- a/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/psi/DjinniInterfaceMemberFunction.java
+++ b/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/psi/DjinniInterfaceMemberFunction.java
@@ -25,6 +25,9 @@ public interface DjinniInterfaceMemberFunction extends PsiElement {
   @NotNull
   PsiElement getSemicolon();
 
+  @Nullable
+  PsiElement getConst();
+
   @NotNull
   PsiElement getIdentifier();
 

--- a/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/psi/impl/DjinniInterfaceMemberFunctionImpl.java
+++ b/src/main/gen/java/com/github/cross_language_cpp/djinni_intellij_plugin/psi/impl/DjinniInterfaceMemberFunctionImpl.java
@@ -63,6 +63,12 @@ public class DjinniInterfaceMemberFunctionImpl extends ASTWrapperPsiElement impl
   }
 
   @Override
+  @Nullable
+  public PsiElement getConst() {
+    return findChildByType(CONST);
+  }
+
+  @Override
   @NotNull
   public PsiElement getIdentifier() {
     return findNotNullChildByType(IDENTIFIER);

--- a/src/main/java/com/github/cross_language_cpp/djinni_intellij_plugin/Djinni.bnf
+++ b/src/main/java/com/github/cross_language_cpp/djinni_intellij_plugin/Djinni.bnf
@@ -129,7 +129,7 @@ interfaceTypeVariant ::= interface generator*
 
 interfaceMember ::= constMember | interfaceMemberFunction
 
-interfaceMemberFunction ::= [static] identifier LEFT_PARAM_BRACE interfaceFunctionParamList? RIGHT_PARAM_BRACE [COLON typeReference] SEMICOLON
+interfaceMemberFunction ::= [static | const] identifier LEFT_PARAM_BRACE interfaceFunctionParamList? RIGHT_PARAM_BRACE [COLON typeReference] SEMICOLON
 
 interfaceFunctionParamList ::=  (interfaceFunctionParam ',' interfaceFunctionParamList) | interfaceFunctionParam
 

--- a/src/main/java/com/github/cross_language_cpp/djinni_intellij_plugin/DjinniColorSettingsPage.java
+++ b/src/main/java/com/github/cross_language_cpp/djinni_intellij_plugin/DjinniColorSettingsPage.java
@@ -98,6 +98,7 @@ public class DjinniColorSettingsPage implements ColorSettingsPage {
             "my_cpp_interface = interface +c {\n" +
             "    method_returning_nothing(value: i32);\n" +
             "    method_returning_some_type(key: string): another_record;\n" +
+            "    const method_changing_nothing(): i32;\n" +
             "    static get_version(): i32;\n" +
             "\n" +
             "    # Interfaces can also have constants\n" +


### PR DESCRIPTION
fixes #17 

the following rules seem to exist in the djinni IDL:
- +c interface methods can be `const` or `static` (see [documentation](https://github.com/cross-language-cpp/djinni#special-methods-for-c-only))
- > +c method cannot be both `static` and `const`
  
   *(error message from the generator)*
- > `const` method not allowed for +j or +o +p interfaces 

   *(error message from the generator. Why +p? Idk 🤷 Sounds like this string has sneaked into main from the python branch by accident?)*
- > static not allowed for +j or +o interfaces

   *(error message from the generator)*

I cannot implement the relationship between interface type (+c/+j/+o) and member function without understanding how the plugin works 🙈 
So I chose this compromise as a quick solution:
```
interfaceMemberFunction ::= [static | const] identifier LEFT_PARAM_BRACE interfaceFunctionParamList? RIGHT_PARAM_BRACE [COLON typeReference] SEMICOLON
```

Enjoy 😋 